### PR TITLE
Use @types/lodash for TypeScript integration when invoking `uniqWith`

### DIFF
--- a/lib/TermUtil.ts
+++ b/lib/TermUtil.ts
@@ -1,3 +1,4 @@
+import * as _ from "lodash";
 import * as RDF from "rdf-js";
 
 /**
@@ -17,7 +18,7 @@ export const TERM_TYPES = [ 'NamedNode', 'BlankNode', 'Literal', 'Variable', 'De
  * @return {T[]} A new array of unique RDFJS terms.
  */
 export function uniqTerms<T extends RDF.Term>(terms: T[]): T[] {
-  return require('lodash.uniqwith')(terms, (termA: RDF.Term, termB: RDF.Term) => termA.equals(termB));
+  return <T[]> _.uniqWith(terms, (termA: RDF.Term, termB: RDF.Term) => termA.equals(termB));
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -31,10 +31,12 @@
   ],
   "dependencies": {
     "@rdfjs/data-model": "^1.1.1",
+    "lodash": "^4.17.15",
     "lodash.uniqwith": "^4.5.0"
   },
   "devDependencies": {
     "@types/jest": "^24.0.0",
+    "@types/lodash": "^4.14.138",
     "coveralls": "^3.0.0",
     "jest": "^23.4.1",
     "manual-git-changelog": "^1.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -120,6 +120,11 @@
   resolved "https://registry.yarnpkg.com/@types/jest/-/jest-24.0.0.tgz#848492026c327b3548d92be0352a545c36a21e8a"
   integrity sha512-kOafJnUTnMd7/OfEO/x3I47EHswNjn+dbz9qk3mtonr1RvKT+1FGVxnxAx08I9K8Tl7j9hpoJRE7OCf+t10fng==
 
+"@types/lodash@^4.14.138":
+  version "4.14.138"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.138.tgz#34f52640d7358230308344e579c15b378d91989e"
+  integrity sha512-A4uJgHz4hakwNBdHNPdxOTkYmXNgmUAKLbXZ7PKGslgeV0Mb8P3BlbYfPovExek1qnod4pDfRbxuzcVs3dlFLg==
+
 "@types/node@*":
   version "8.5.1"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-8.5.1.tgz#4ec3020bcdfe2abffeef9ba3fbf26fca097514b5"
@@ -2568,6 +2573,11 @@ lodash@^4.14.0, lodash@^4.17.4:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
   integrity sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=
+
+lodash@^4.17.15:
+  version "4.17.15"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
+  integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
 
 log-driver@^1.2.5:
   version "1.2.5"


### PR DESCRIPTION
Hello, thank you very much for this incredible contribution to developers working with Linked Data!  The work which is being undertaken by you and @RubenVerborgh is truly astounding.

I've been trying to test using this package within a React/Redux application, and was finding errors within the scope of https://github.com/rubensworks/rdf-terms.js/blob/master/lib/TermUtil.ts#L20.  This introduces `lodash` functions within TypeScript using `@types/lodash`.

Please freely reject these proposed changes if they are unnecessary or problematic.

Thank you again for these packages.